### PR TITLE
Added methods in driver class to switch to next tab and parent tab

### DIFF
--- a/src/main/java/com/znsio/e2e/tools/Driver.java
+++ b/src/main/java/com/znsio/e2e/tools/Driver.java
@@ -427,8 +427,7 @@ public class Driver {
             iterator.next();
             driver.switchTo().window(iterator.next());
         } catch (NoSuchElementException e) {
-            LOGGER.error("Unable to get next window handle.");
-            e.printStackTrace();
+            throw new NoSuchElementException("Unable to get next window handle.", e);
         }
     }
 
@@ -436,8 +435,7 @@ public class Driver {
         try {
             driver.switchTo().window(driver.getWindowHandles().iterator().next());
         }catch (NoSuchElementException e){
-            LOGGER.error("No previous tab found.");
-            e.printStackTrace();
+            throw new NoSuchElementException("No previous tab found.", e);
         }
     }
 }

--- a/src/main/java/com/znsio/e2e/tools/Driver.java
+++ b/src/main/java/com/znsio/e2e/tools/Driver.java
@@ -21,6 +21,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -419,5 +420,24 @@ public class Driver {
     public void scrollTillElementIntoView(By elementId) {
         WebElement element = driver.findElement(elementId);
         ((JavascriptExecutor) driver).executeScript("arguments[0].scrollIntoView(true);", element);
+    }
+    public void switchToNextTab() {
+        Iterator<String> iterator = driver.getWindowHandles().iterator();
+        try {
+            iterator.next();
+            driver.switchTo().window(iterator.next());
+        } catch (NoSuchElementException e) {
+            LOGGER.error("Unable to get next window handle.");
+            e.printStackTrace();
+        }
+    }
+
+    public void switchToParentTab() {
+        try {
+            driver.switchTo().window(driver.getWindowHandles().iterator().next());
+        }catch (NoSuchElementException e){
+            LOGGER.error("No previous tab found.");
+            e.printStackTrace();
+        }
     }
 }


### PR DESCRIPTION
Created two methods in Driver.java class.
1. switchToNextTab - using this method, driver can switch to next tab. NoSuchElementException is also handled in case there is no next tab present.
2. switchToParentTab - using this method, driver can switch to parent tab.