### PR TITLE
Update BrowserStackSetup.java

### DIFF
--- a/src/main/java/com/znsio/e2e/runner/BrowserStackSetup.java
+++ b/src/main/java/com/znsio/e2e/runner/BrowserStackSetup.java
@@ -157,6 +157,7 @@ public class BrowserStackSetup {
         bsLocalArgs.put("v", "true");
         bsLocalArgs.put("localIdentifier", id);
         bsLocalArgs.put("forcelocal", "true");
+        bsLocalArgs.put("verbose", 3);
         try {
             LOGGER.info("Is BrowserStackLocal running? - " + bsLocal.isRunning());
             if(configsBoolean.get(CLOUD_USE_PROXY)) {

--- a/src/main/java/com/znsio/e2e/runner/BrowserStackSetup.java
+++ b/src/main/java/com/znsio/e2e/runner/BrowserStackSetup.java
@@ -157,7 +157,7 @@ public class BrowserStackSetup {
         bsLocalArgs.put("v", "true");
         bsLocalArgs.put("localIdentifier", id);
         bsLocalArgs.put("forcelocal", "true");
-        bsLocalArgs.put("verbose", 3);
+        bsLocalArgs.put("verbose", "3");
         try {
             LOGGER.info("Is BrowserStackLocal running? - " + bsLocal.isRunning());
             if(configsBoolean.get(CLOUD_USE_PROXY)) {


### PR DESCRIPTION
Added verbose flag with value 3 in bsLocalArgs as per recommendation by BrowserStack people. This option sets the level of logging required. 
1 to debug issues related to setting up connections.  2 for logs related to network information. 
3 to dump all communication to local servers for each request and response. The default value for this option is 1.