### PR TITLE
Enhancement Todo : Added logic to get device name from browser config json

### DIFF
--- a/configs/browser_config.json
+++ b/configs/browser_config.json
@@ -57,5 +57,9 @@
     "maximize": true,
     "acceptInsecureCerts": true,
     "setUseTechnologyPreview": false
-  }
+  },
+  "tab1": "iPad mini",
+  "tab2": "iPad Pro",
+  "mobile1": "iPhone SE",
+  "mobile2": "iPhone 8"
 }

--- a/src/test/java/com/znsio/teswiz/steps/AppLaunchSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/AppLaunchSteps.java
@@ -68,6 +68,7 @@ public class AppLaunchSteps {
         String browser = details[0];
         String mobileEmulation = details[1];
 
+        //Fetching deviceName from Browser Config json file based on 'mobileEmulation' variable
         String deviceName = new JSONObject(Runner.getBrowserConfigFileContents()).getString(mobileEmulation);
         LOGGER.info("Device name from browser config file :" + deviceName);
         context.addTestState(TEST_CONTEXT.MOBILE_EMULATION_DEVICE, deviceName);

--- a/src/test/java/com/znsio/teswiz/steps/AppLaunchSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/AppLaunchSteps.java
@@ -9,6 +9,7 @@ import com.znsio.teswiz.runner.Runner;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import org.apache.log4j.Logger;
+import org.json.JSONObject;
 
 import java.util.Locale;
 
@@ -67,12 +68,9 @@ public class AppLaunchSteps {
         String browser = details[0];
         String mobileEmulation = details[1];
 
-        //TODO add logic to get deviceName from Browser Config json file based on
-        // 'mobileEmulation' variable
-        // & add it in context for future reference
-
-        //upon fetching the value of deviceName, replace it in below line
-        context.addTestState(TEST_CONTEXT.MOBILE_EMULATION_DEVICE, "deviceName");
+        String deviceName = new JSONObject(Runner.getBrowserConfigFileContents()).getString(mobileEmulation);
+        LOGGER.info("Device name from browser config file :" + deviceName);
+        context.addTestState(TEST_CONTEXT.MOBILE_EMULATION_DEVICE, deviceName);
 
         return browser;
     }


### PR DESCRIPTION
This PR is intended to add logic for fetching device name from browser config json file with parsed mobile emulation variable.
