### PR TITLE
Added waitTillElementIsInvisible() to the Driver Class

### DIFF
--- a/src/main/java/com/znsio/teswiz/runner/Driver.java
+++ b/src/main/java/com/znsio/teswiz/runner/Driver.java
@@ -8,7 +8,6 @@ import com.znsio.teswiz.exceptions.InvalidTestDataException;
 import io.appium.java_client.AppiumBy;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.HidesKeyboard;
-import io.appium.java_client.AppiumBy;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.android.HasNotifications;
 import io.appium.java_client.android.StartsActivity;
@@ -762,5 +761,13 @@ public class Driver {
         } else {
             throw new NotImplementedException("relaunchApp method is not implemented for " + Runner.getPlatform());
         }
+    }
+
+    public boolean waitTillElementIsInvisible(By elementId) {
+        return waitTillElementIsInvisible(elementId, 10);
+    }
+
+    public boolean waitTillElementIsInvisible(By elementId, int numberOfSecondsToWait) {
+        return (new WebDriverWait(driver, Duration.ofSeconds(numberOfSecondsToWait)).until(ExpectedConditions.invisibilityOfElementLocated(elementId)));
     }
 }


### PR DESCRIPTION
We Already had waitTillElementIsVisible() in Teswiz, but for a test case I want to check the invisibility of an element. Thus, Created new Overloaded methods waitTillElementIsInvisible() Using the Expected conditions Class.

Added 2 new methods:
1. waitTillElementIsInvisible(webElement)
2. waitTillElementIsInvisible(webElement, numberOfSecondsToWait)