### PR TITLE
Fix for Log4j2 unreadable logs issue 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ shadowJar {
     manifest {
         attributes "Main-Class": "com.znsio.e2e.runner.Runner"
     }
+    transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer)
 }
 
 tasks.register('sourcesJar', Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ shadowJar {
     manifest {
         attributes "Main-Class": "com.znsio.e2e.runner.Runner"
     }
-    transform(com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer)
+    exclude "**/Log4j2Plugins.dat"
 }
 
 tasks.register('sourcesJar', Jar) {


### PR DESCRIPTION
This PR contains fix for Log4j2 unreadable logs issue - https://github.com/znsio/teswiz/issues/506

Excluded the Log4j2Plugins.dat ( cache file is included in the jar. )
If a dependency contains log4j2 plugin, a Log4j2Plugins.dat cache file is included in the jar. When the Maven shade plugin is used to merge multiple jars with a Log4j2Plugins.dat file, only one will survive. Without the plugin definitions, errors are shown on startup. [[Log4j2 issue](https://issues.apache.org/jira/browse/LOG4J2-673)]
