### PR TITLE
Updated Log4j 2.x Apis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
         aspectJVersion = "1.9.20.1"
         webDriverManager = '5.5.3'
         specmaticVersion = '1.0.4'
-        log4jVersion = '2.22.0'
     }
 }
 
@@ -71,14 +70,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$project.fasterxmlJacksonVersion"
     implementation "com.konghq:unirest-java:$project.unirestVersion"
     implementation "org.assertj:assertj-core:$project.assertJVersion"
-    implementation ("com.github.AppiumTestDistribution:AppiumTestDistribution:$project.atdVersion") {
-        exclude group: 'log4j', module: 'log4j'
-    }
-    // Migrating from Log4j 1.x to 2.x - https://logging.apache.org/log4j/2.x/manual/migration.html
-    implementation "org.apache.logging.log4j:log4j-1.2-api:$project.log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-api:$project.log4jVersion"
-    implementation "org.apache.logging.log4j:log4j-core:$project.log4jVersion"
-
+    implementation ("com.github.AppiumTestDistribution:AppiumTestDistribution:$project.atdVersion")
     implementation "org.seleniumhq.selenium:selenium-http-jdk-client:$project.seleniumVersion"
     implementation "org.apache.commons:commons-lang3:$project.commonsLang3Version"
     implementation "org.apache.commons:commons-rng-simple:$project.commonsRngSimpleVersion"

--- a/src/main/java/com/znsio/teswiz/aspect/AspectJMethodLoggers.java
+++ b/src/main/java/com/znsio/teswiz/aspect/AspectJMethodLoggers.java
@@ -1,13 +1,13 @@
 package com.znsio.teswiz.aspect;
 
-import org.apache.log4j.*;
+import org.apache.logging.log4j.*;
 import org.aspectj.lang.*;
 
 import java.lang.reflect.*;
 import java.util.stream.*;
 
 public class AspectJMethodLoggers {
-    private static final Logger LOGGER = Logger.getLogger(AspectJMethodLoggers.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AspectJMethodLoggers.class.getName());
 
     private AspectJMethodLoggers() {
     }

--- a/src/main/java/com/znsio/teswiz/aspect/AspectLogging.java
+++ b/src/main/java/com/znsio/teswiz/aspect/AspectLogging.java
@@ -2,13 +2,14 @@ package com.znsio.teswiz.aspect;
 
 import com.context.SessionContext;
 import com.context.TestExecutionContext;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.*;
 
 @Aspect
 public class AspectLogging {
-    private static final Logger LOGGER = Logger.getLogger(AspectLogging.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AspectLogging.class.getName());
     private final TestExecutionContext context;
 
     public AspectLogging() {

--- a/src/main/java/com/znsio/teswiz/listener/CucumberPlatformScenarioListener.java
+++ b/src/main/java/com/znsio/teswiz/listener/CucumberPlatformScenarioListener.java
@@ -12,7 +12,8 @@ import io.cucumber.plugin.event.TestCaseFinished;
 import io.cucumber.plugin.event.TestCaseStarted;
 import io.cucumber.plugin.event.TestRunFinished;
 import io.cucumber.plugin.event.TestRunStarted;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.util.HashMap;
@@ -21,7 +22,7 @@ import java.util.Map;
 
 public class CucumberPlatformScenarioListener
         implements ConcurrentEventListener {
-    private static final Logger LOGGER = Logger.getLogger(
+    private static final Logger LOGGER = LogManager.getLogger(
             CucumberPlatformScenarioListener.class.getName());
     private final Map<String, Integer> scenarioRunCounts = new HashMap<>();
 

--- a/src/main/java/com/znsio/teswiz/listener/CucumberPlatformScenarioReporterListener.java
+++ b/src/main/java/com/znsio/teswiz/listener/CucumberPlatformScenarioReporterListener.java
@@ -3,13 +3,14 @@ package com.znsio.teswiz.listener;
 import com.epam.reportportal.cucumber.ScenarioReporter;
 import com.epam.reportportal.utils.MemoizingSupplier;
 import com.epam.ta.reportportal.ws.model.StartTestItemRQ;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Calendar;
 
 public class CucumberPlatformScenarioReporterListener
         extends ScenarioReporter {
-    private static final Logger LOGGER = Logger.getLogger(
+    private static final Logger LOGGER = LogManager.getLogger(
             CucumberPlatformScenarioReporterListener.class.getName());
     private static final String DUMMY_ROOT_SUITE_NAME = "End-2-End Tests";
     private static final String RP_STORY_TYPE = "SUITE";

--- a/src/main/java/com/znsio/teswiz/runner/AppiumDriverManager.java
+++ b/src/main/java/com/znsio/teswiz/runner/AppiumDriverManager.java
@@ -17,7 +17,8 @@ import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.appmanagement.ApplicationState;
 import io.appium.java_client.ios.IOSDriver;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.NoSuchSessionException;
@@ -38,7 +39,7 @@ import static com.znsio.teswiz.runner.Setup.CAPS;
 class AppiumDriverManager {
     private static final int MAX_NUMBER_OF_APPIUM_DRIVERS = Runner.getMaxNumberOfAppiumDrivers();
     private static final List<DriverSession> additionalDevices = new ArrayList<>();
-    private static final Logger LOGGER = Logger.getLogger(AppiumDriverManager.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AppiumDriverManager.class.getName());
     private static final String CAPABILITIES = "CAPABILITIES: ";
     private static int numberOfAppiumDriversUsed = 0;
 

--- a/src/main/java/com/znsio/teswiz/runner/BrowserDriverManager.java
+++ b/src/main/java/com/znsio/teswiz/runner/BrowserDriverManager.java
@@ -10,7 +10,8 @@ import com.znsio.teswiz.tools.JsonSchemaValidator;
 import com.znsio.teswiz.tools.ReportPortalLogger;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import io.github.bonigarcia.wdm.WebDriverManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -48,7 +49,7 @@ import static com.znsio.teswiz.runner.Setup.CAPS;
 import static com.appium.utils.OverriddenVariable.*;
 
 class BrowserDriverManager {
-    private static final Logger LOGGER = Logger.getLogger(BrowserDriverManager.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(BrowserDriverManager.class.getName());
     private static final int MAX_NUMBER_OF_WEB_DRIVERS = Runner.getMaxNumberOfWebDrivers();
     private static final String BROWSER_CONFIG_SCHEMA_FILE = "BrowserConfigSchema.json";
     private static final String ACCEPT_INSECURE_CERTS = "acceptInsecureCerts";

--- a/src/main/java/com/znsio/teswiz/runner/BrowserStackDeviceFilter.java
+++ b/src/main/java/com/znsio/teswiz/runner/BrowserStackDeviceFilter.java
@@ -6,7 +6,8 @@ import com.jayway.jsonpath.JsonPath;
 import com.znsio.teswiz.exceptions.InvalidTestDataException;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -20,7 +21,7 @@ import java.util.stream.Collectors;
 import static com.znsio.teswiz.runner.Setup.getCurlProxyCommand;
 
 class BrowserStackDeviceFilter {
-    private static final Logger LOGGER = Logger.getLogger(BrowserStackDeviceFilter.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(BrowserStackDeviceFilter.class.getName());
 
     private BrowserStackDeviceFilter() {
         LOGGER.debug("BrowserStackDeviceFilter - private constructor");

--- a/src/main/java/com/znsio/teswiz/runner/BrowserStackImageInjection.java
+++ b/src/main/java/com/znsio/teswiz/runner/BrowserStackImageInjection.java
@@ -3,7 +3,8 @@ package com.znsio.teswiz.runner;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import com.znsio.teswiz.tools.cmd.CommandLineResponse;
 import io.appium.java_client.AppiumDriver;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.json.JSONObject;
 
 import java.io.File;
@@ -13,7 +14,7 @@ import static com.znsio.teswiz.runner.DeviceSetup.getCloudNameFromCapabilities;
 import static com.znsio.teswiz.tools.Wait.waitFor;
 
 class BrowserStackImageInjection {
-    private static final Logger LOGGER = Logger.getLogger(
+    private static final Logger LOGGER = LogManager.getLogger(
             BrowserStackImageInjection.class.getName());
 
     private static String uploadToCloud(String uploadFilePath, String cloudUser, String cloudKey) {

--- a/src/main/java/com/znsio/teswiz/runner/BrowserStackSetup.java
+++ b/src/main/java/com/znsio/teswiz/runner/BrowserStackSetup.java
@@ -11,7 +11,8 @@ import com.znsio.teswiz.tools.JsonFile;
 import com.znsio.teswiz.tools.Randomizer;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import com.znsio.teswiz.tools.cmd.CommandLineResponse;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.MutableCapabilities;
 
 import java.io.File;
@@ -23,7 +24,7 @@ import static com.znsio.teswiz.runner.Runner.getHostName;
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
 
 class BrowserStackSetup {
-    private static final Logger LOGGER = Logger.getLogger(BrowserStackSetup.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(BrowserStackSetup.class.getName());
     private static final String DEVICE = "device";
     private static Local bsLocal;
 

--- a/src/main/java/com/znsio/teswiz/runner/CustomReports.java
+++ b/src/main/java/com/znsio/teswiz/runner/CustomReports.java
@@ -4,7 +4,8 @@ import com.znsio.teswiz.entities.TEST_CONTEXT;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -16,7 +17,7 @@ import static com.znsio.teswiz.runner.DeviceSetup.getCloudNameFromCapabilities;
 import static com.znsio.teswiz.runner.Setup.*;
 
 class CustomReports {
-    private static final Logger LOGGER = Logger.getLogger(CustomReports.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(CustomReports.class.getName());
 
     private CustomReports() {
         LOGGER.debug("CustomReports - private constructor");

--- a/src/main/java/com/znsio/teswiz/runner/DeviceSetup.java
+++ b/src/main/java/com/znsio/teswiz/runner/DeviceSetup.java
@@ -6,7 +6,8 @@ import com.znsio.teswiz.exceptions.InvalidTestDataException;
 import com.znsio.teswiz.tools.JsonFile;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import com.znsio.teswiz.tools.cmd.CommandLineResponse;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -38,7 +39,7 @@ import static com.znsio.teswiz.runner.Setup.PLUGIN;
 import static com.znsio.teswiz.runner.Setup.RUN_IN_CI;
 
 class DeviceSetup {
-    private static final Logger LOGGER = Logger.getLogger(DeviceSetup.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(DeviceSetup.class.getName());
     private static final String DEFAULT_TEMP_SAMPLE_APP_DIRECTORY =
             System.getProperty("user.dir") + File.separator +
                     "temp" + File.separator + "sampleApps";

--- a/src/main/java/com/znsio/teswiz/runner/Driver.java
+++ b/src/main/java/com/znsio/teswiz/runner/Driver.java
@@ -14,7 +14,8 @@ import io.appium.java_client.android.StartsActivity;
 import io.appium.java_client.ios.IOSDriver;
 import io.appium.java_client.remote.SupportsContextSwitching;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
@@ -50,7 +51,7 @@ import static java.util.Arrays.asList;
 public class Driver {
     public static final String WEB_DRIVER = "WebDriver";
     public static final String APPIUM_DRIVER = "AppiumDriver";
-    private static final Logger LOGGER = Logger.getLogger(Driver.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(Driver.class.getName());
     private final String type;
     private final WebDriver driver;
     private final String userPersona;

--- a/src/main/java/com/znsio/teswiz/runner/Drivers.java
+++ b/src/main/java/com/znsio/teswiz/runner/Drivers.java
@@ -7,7 +7,8 @@ import com.znsio.teswiz.exceptions.InvalidTestDataException;
 import io.cucumber.java.Scenario;
 import io.cucumber.java.Status;
 import kong.unirest.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.Capabilities;
@@ -25,7 +26,7 @@ import static io.appium.java_client.remote.options.SupportsDeviceNameOption.DEVI
 import static org.openqa.selenium.remote.CapabilityType.BROWSER_NAME;
 
 public class Drivers {
-    private static final Logger LOGGER = Logger.getLogger(Drivers.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(Drivers.class.getName());
     private static final String NO_DRIVER_FOUND_FOR_USER_PERSONA = "No Driver found for user " +
                                                                    "persona: '%s'";
 

--- a/src/main/java/com/znsio/teswiz/runner/HeadSpinSetup.java
+++ b/src/main/java/com/znsio/teswiz/runner/HeadSpinSetup.java
@@ -6,7 +6,8 @@ import com.znsio.teswiz.exceptions.InvalidTestDataException;
 import com.znsio.teswiz.tools.JsonFile;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import com.znsio.teswiz.tools.cmd.CommandLineResponse;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,7 +17,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static com.znsio.teswiz.runner.Runner.NOT_SET;
 
 class HeadSpinSetup {
-    private static final Logger LOGGER = Logger.getLogger(HeadSpinSetup.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(HeadSpinSetup.class.getName());
     private static final String PLATFORM_VERSION = "platformVersion";
 
     private HeadSpinSetup() {

--- a/src/main/java/com/znsio/teswiz/runner/LocalDevicesSetup.java
+++ b/src/main/java/com/znsio/teswiz/runner/LocalDevicesSetup.java
@@ -2,7 +2,8 @@ package com.znsio.teswiz.runner;
 
 import com.znsio.teswiz.exceptions.EnvironmentSetupException;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import se.vidstige.jadb.JadbConnection;
 import se.vidstige.jadb.JadbDevice;
@@ -23,7 +24,7 @@ import static com.znsio.teswiz.runner.Setup.EXECUTED_ON;
 import static com.znsio.teswiz.runner.Setup.PARALLEL;
 
 class LocalDevicesSetup {
-    private static final Logger LOGGER = Logger.getLogger(LocalDevicesSetup.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(LocalDevicesSetup.class.getName());
     private static final String APPIUM_SETTINGS = "io.appium.settings";
     private static final String UNINSTALL = "uninstall";
     private static final String GETPROP = "getprop";

--- a/src/main/java/com/znsio/teswiz/runner/PCloudySetup.java
+++ b/src/main/java/com/znsio/teswiz/runner/PCloudySetup.java
@@ -8,7 +8,8 @@ import com.znsio.teswiz.exceptions.EnvironmentSetupException;
 import com.znsio.teswiz.tools.JsonFile;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import com.znsio.teswiz.tools.cmd.CommandLineResponse;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -22,7 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static com.znsio.teswiz.runner.Setup.*;
 
 class PCloudySetup {
-    private static final Logger LOGGER = Logger.getLogger(PCloudySetup.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(PCloudySetup.class.getName());
     private static final String CURL_INSECURE = "curl --insecure";
     private static final String RESULT = "result";
 

--- a/src/main/java/com/znsio/teswiz/runner/Runner.java
+++ b/src/main/java/com/znsio/teswiz/runner/Runner.java
@@ -42,7 +42,6 @@ public class Runner {
     }
 
     public Runner(String configFilePath, String stepDefDirName, String featuresDirName) {
-        setLog4jCompatibility();
         Path path = Paths.get(configFilePath);
         if(!Files.exists(path)) {
             throw new InvalidTestDataException(
@@ -51,11 +50,6 @@ public class Runner {
         Setup.load(configFilePath);
         List<String> cukeArgs = Setup.getExecutionArguments();
         run(cukeArgs, stepDefDirName, featuresDirName);
-    }
-
-    private static void setLog4jCompatibility() {
-        // Migrating from Log4j 1.x to 2.x - https://logging.apache.org/log4j/2.x/manual/migration.html
-        System.setProperty("log4j1.compatibility", "true");
     }
 
     public static Platform getPlatformForUser(String userPersona) {

--- a/src/main/java/com/znsio/teswiz/runner/Runner.java
+++ b/src/main/java/com/znsio/teswiz/runner/Runner.java
@@ -6,7 +6,8 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.entities.TEST_CONTEXT;
 import com.znsio.teswiz.exceptions.InvalidTestDataException;
 import io.cucumber.core.cli.Main;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -33,7 +34,7 @@ public class Runner {
     public static final String INFO = "INFO";
     public static final String WARN = "WARN";
 
-    private static final Logger LOGGER = Logger.getLogger(Runner.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(Runner.class.getName());
     private static final String INVALID_KEY_MESSAGE = "Invalid key name ('%s') provided";
 
     public Runner() {

--- a/src/main/java/com/znsio/teswiz/runner/Setup.java
+++ b/src/main/java/com/znsio/teswiz/runner/Setup.java
@@ -11,7 +11,8 @@ import com.znsio.teswiz.tools.JsonFile;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import com.znsio.teswiz.tools.cmd.CommandLineResponse;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.log4j.PropertyConfigurator;
 import org.jetbrains.annotations.NotNull;
 
@@ -84,7 +85,7 @@ class Setup {
     static final String APPLITOOLS_CONFIGURATION = "APPLITOOLS_CONFIGURATION";
     private static final String LAUNCH_NAME_SUFFIX = "LAUNCH_NAME_SUFFIX";
     private static final String REMOTE_WEBDRIVER_GRID_PORT_KEY = "REMOTE_WEBDRIVER_GRID_PORT_KEY";
-    private static final Logger LOGGER = Logger.getLogger(Setup.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(Setup.class.getName());
     private static final String DEFAULT_LOG_PROPERTIES_FILE = "/defaultLog4j.properties";
     private static final String DEFAULT_WEBDRIVER_GRID_PORT = "4444";
     private static final String DEFAULT_WEBDRIVER_GRID_HOST_NAME = "localhost";

--- a/src/main/java/com/znsio/teswiz/runner/UserPersonaDetails.java
+++ b/src/main/java/com/znsio/teswiz/runner/UserPersonaDetails.java
@@ -1,7 +1,8 @@
 package com.znsio.teswiz.runner;
 
 import com.znsio.teswiz.entities.Platform;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.Capabilities;
 
@@ -10,7 +11,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class UserPersonaDetails {
-    private final Logger LOGGER = Logger.getLogger(UserPersonaDetails.class.getName());
+    private final Logger LOGGER = LogManager.getLogger(UserPersonaDetails.class.getName());
     private final ConcurrentHashMap<String, Capabilities> capabilities = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, String> apps = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Driver> drivers = new ConcurrentHashMap<>();

--- a/src/main/java/com/znsio/teswiz/runner/Visual.java
+++ b/src/main/java/com/znsio/teswiz/runner/Visual.java
@@ -23,7 +23,8 @@ import com.znsio.teswiz.exceptions.InvalidTestDataException;
 import com.znsio.teswiz.exceptions.VisualTestSetupException;
 import com.znsio.teswiz.tools.ReportPortalLogger;
 import com.znsio.teswiz.tools.ScreenShotManager;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.Dimension;
@@ -43,7 +44,7 @@ import java.util.Set;
 import static com.znsio.teswiz.runner.Runner.*;
 
 public class Visual {
-    private static final Logger LOGGER = Logger.getLogger(Visual.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(Visual.class.getName());
     private static final String DEFAULT_APPLITOOLS_SERVER_URL = "https://eyesapi.applitools.com";
     private final com.applitools.eyes.selenium.Eyes eyesOnWeb;
     private final com.applitools.eyes.appium.Eyes eyesOnApp;

--- a/src/main/java/com/znsio/teswiz/steps/Hooks.java
+++ b/src/main/java/com/znsio/teswiz/steps/Hooks.java
@@ -9,14 +9,15 @@ import com.znsio.teswiz.runner.UserPersonaDetails;
 import com.znsio.teswiz.tools.ReportPortalLogger;
 import com.znsio.teswiz.tools.ScreenShotManager;
 import io.cucumber.java.Scenario;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import java.util.Map;
 import java.util.Properties;
 
 public class Hooks {
-    private static final Logger LOGGER = Logger.getLogger(Hooks.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(Hooks.class.getName());
 
     public void beforeScenario(Scenario scenario) {
         long threadId = Thread.currentThread().getId();

--- a/src/main/java/com/znsio/teswiz/steps/RunCukes.java
+++ b/src/main/java/com/znsio/teswiz/steps/RunCukes.java
@@ -7,12 +7,13 @@ import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
 import io.cucumber.testng.AbstractTestNGCucumberTests;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.testng.annotations.DataProvider;
 
 public class RunCukes
         extends AbstractTestNGCucumberTests {
-    private static final Logger LOGGER = Logger.getLogger(RunCukes.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(RunCukes.class.getName());
     private final TestExecutionContext context;
 
     public RunCukes() {

--- a/src/main/java/com/znsio/teswiz/tools/JsonFile.java
+++ b/src/main/java/com/znsio/teswiz/tools/JsonFile.java
@@ -3,7 +3,8 @@ package com.znsio.teswiz.tools;
 import com.google.gson.*;
 import com.znsio.teswiz.exceptions.EnvironmentSetupException;
 import com.znsio.teswiz.exceptions.InvalidTestDataException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.*;
 import java.nio.file.Files;
@@ -12,7 +13,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 public class JsonFile {
-    private static final Logger LOGGER = Logger.getLogger(JsonFile.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(JsonFile.class.getName());
 
     private JsonFile() {
     }

--- a/src/main/java/com/znsio/teswiz/tools/JsonSchemaValidator.java
+++ b/src/main/java/com/znsio/teswiz/tools/JsonSchemaValidator.java
@@ -1,7 +1,8 @@
 package com.znsio.teswiz.tools;
 
 import com.znsio.teswiz.exceptions.InvalidTestDataException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.everit.json.schema.Schema;
 import org.everit.json.schema.ValidationException;
 import org.everit.json.schema.loader.SchemaLoader;
@@ -11,7 +12,7 @@ import org.json.JSONTokener;
 import java.io.InputStream;
 
 public class JsonSchemaValidator {
-    private static final Logger LOGGER = Logger.getLogger(JsonSchemaValidator.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(JsonSchemaValidator.class.getName());
 
     public static JSONObject validateJsonFileAgainstSchema(String jsonFilePath, String jsonContents,
                                                            String schemaFile) {

--- a/src/main/java/com/znsio/teswiz/tools/ReportPortalLogger.java
+++ b/src/main/java/com/znsio/teswiz/tools/ReportPortalLogger.java
@@ -1,7 +1,8 @@
 package com.znsio.teswiz.tools;
 
 import com.epam.reportportal.service.ReportPortal;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.util.Date;
@@ -9,7 +10,7 @@ import java.util.Date;
 import static com.znsio.teswiz.runner.Runner.*;
 
 public class ReportPortalLogger {
-    private static final Logger LOGGER = Logger.getLogger(ReportPortalLogger.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(ReportPortalLogger.class.getName());
 
     private ReportPortalLogger() {
         LOGGER.debug("ReportPortalLogger - private constructor");

--- a/src/main/java/com/znsio/teswiz/tools/ScreenShotManager.java
+++ b/src/main/java/com/znsio/teswiz/tools/ScreenShotManager.java
@@ -6,7 +6,8 @@ import com.znsio.teswiz.entities.TEST_CONTEXT;
 import com.znsio.teswiz.runner.Runner;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -16,7 +17,7 @@ import java.io.IOException;
 
 public class ScreenShotManager {
 
-    private static final Logger LOGGER = Logger.getLogger(ScreenShotManager.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(ScreenShotManager.class.getName());
     private final TestExecutionContext context;
     private final String directoryPath;
     private int counter;

--- a/src/main/java/com/znsio/teswiz/tools/Wait.java
+++ b/src/main/java/com/znsio/teswiz/tools/Wait.java
@@ -1,9 +1,10 @@
 package com.znsio.teswiz.tools;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class Wait {
-    private static final Logger LOGGER = Logger.getLogger(Wait.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(Wait.class.getName());
 
     public synchronized static void waitFor(int seconds) {
         LOGGER.info("Wait for " + seconds + " seconds");

--- a/src/main/java/com/znsio/teswiz/tools/cmd/CommandLineExecutor.java
+++ b/src/main/java/com/znsio/teswiz/tools/cmd/CommandLineExecutor.java
@@ -3,14 +3,15 @@ package com.znsio.teswiz.tools.cmd;
 import com.znsio.teswiz.exceptions.CommandLineExecutorException;
 import com.znsio.teswiz.runner.Runner;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
 public class CommandLineExecutor {
-    private static final Logger LOGGER = Logger.getLogger(CommandLineExecutor.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(CommandLineExecutor.class.getName());
     private static final int DEFAULT_COMMAND_TIMEOUT = 60;
 
     private CommandLineExecutor() {}

--- a/src/test/java/com/znsio/teswiz/aspect/AspectLogging.java
+++ b/src/test/java/com/znsio/teswiz/aspect/AspectLogging.java
@@ -2,13 +2,14 @@ package com.znsio.teswiz.aspect;
 
 import com.context.SessionContext;
 import com.context.TestExecutionContext;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.*;
 
 @Aspect
 public class AspectLogging {
-    private static final Logger LOGGER = Logger.getLogger(AspectLogging.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AspectLogging.class.getName());
     private final TestExecutionContext context;
 
     public AspectLogging() {

--- a/src/test/java/com/znsio/teswiz/businessLayer/ajio/HomeBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/ajio/HomeBL.java
@@ -6,13 +6,14 @@ import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.screen.ajio.HomeScreen;
 import com.znsio.teswiz.screen.ajio.SearchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class HomeBL {
-    private static final Logger LOGGER = Logger.getLogger(HomeBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(HomeBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/ajio/ProductBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/ajio/ProductBL.java
@@ -7,13 +7,14 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.screen.ajio.CartScreen;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
 import com.znsio.teswiz.screen.ajio.SearchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ProductBL {
-    private static final Logger LOGGER = Logger.getLogger(ProductBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(ProductBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/ajio/SearchBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/ajio/SearchBL.java
@@ -8,7 +8,8 @@ import com.znsio.teswiz.screen.ajio.CartScreen;
 import com.znsio.teswiz.screen.ajio.HomeScreen;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
 import com.znsio.teswiz.screen.ajio.SearchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import java.util.Map;
@@ -16,7 +17,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class SearchBL {
-    private static final Logger LOGGER = Logger.getLogger(SearchBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(SearchBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/autoscroll/AutoScrollBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/autoscroll/AutoScrollBL.java
@@ -5,14 +5,15 @@ import com.znsio.teswiz.entities.Direction;
 import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.screen.autoscroll.AutoScrollScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class AutoScrollBL {
 
-    private static final Logger LOGGER = Logger.getLogger(AutoScrollBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AutoScrollBL.class.getName());
     private final TestExecutionContext context;
     private final String currentUserPersona;
     private final Platform currentPlatform;

--- a/src/test/java/com/znsio/teswiz/businessLayer/calculator/CalculatorBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/calculator/CalculatorBL.java
@@ -6,11 +6,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.calculator.CalculatorScreen;
 import com.znsio.teswiz.screen.calculator.NewCalculatorScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.SoftAssertions;
 
 public class CalculatorBL {
-    private static final Logger LOGGER = Logger.getLogger(CalculatorBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(CalculatorBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/confengine/ConfEngineBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/confengine/ConfEngineBL.java
@@ -5,11 +5,12 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.confengine.ConfEngineLandingScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class ConfEngineBL {
-    private static final Logger LOGGER = Logger.getLogger(ConfEngineBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(ConfEngineBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/cryptoAPI/CryptoAPIBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/cryptoAPI/CryptoAPIBL.java
@@ -4,14 +4,15 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.services.UnirestService;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CryptoAPIBL {
-    private static final Logger LOGGER = Logger.getLogger(CryptoAPIBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(CryptoAPIBL.class.getName());
     private final Map<String, Object> testData = Runner.getTestDataAsMap("Crypto_API");
     private final String base_URL = testData.get("url").toString();
 

--- a/src/test/java/com/znsio/teswiz/businessLayer/dineout/DineoutSearchBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/dineout/DineoutSearchBL.java
@@ -5,11 +5,12 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.dineout.DineoutLandingScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.assertj.core.api.SoftAssertions;
 
 public class DineoutSearchBL {
-    private static final Logger LOGGER = Logger.getLogger(DineoutSearchBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(DineoutSearchBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/googlesearch/SearchResultsBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/googlesearch/SearchResultsBL.java
@@ -3,11 +3,12 @@ package com.znsio.teswiz.businessLayer.googlesearch;
 import com.context.TestExecutionContext;
 import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class SearchResultsBL {
-    private static final Logger LOGGER = Logger.getLogger(SearchResultsBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(SearchResultsBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/helloWorld/HelloWorldBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/helloWorld/HelloWorldBL.java
@@ -6,11 +6,12 @@ import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.screen.ScreenShotScreen;
 import com.znsio.teswiz.screen.helloWorld.HelloWorldScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class HelloWorldBL {
-    private static final Logger LOGGER = Logger.getLogger(HelloWorldBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(HelloWorldBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/indigo/FlightResultsBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/indigo/FlightResultsBL.java
@@ -4,11 +4,12 @@ import com.context.TestExecutionContext;
 import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class FlightResultsBL {
-    private static final Logger LOGGER = Logger.getLogger(FlightResultsBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(FlightResultsBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/indigo/GiftVoucherBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/indigo/GiftVoucherBL.java
@@ -6,13 +6,14 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.indigo.IndigoGiftVouchersScreen;
 import com.znsio.teswiz.screen.indigo.IndigoHomeScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class GiftVoucherBL {
-    private static final Logger LOGGER = Logger.getLogger(GiftVoucherBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(GiftVoucherBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/indigo/IndigoBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/indigo/IndigoBL.java
@@ -5,11 +5,12 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.indigo.IndigoHomeScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class IndigoBL {
-    private static final Logger LOGGER = Logger.getLogger(IndigoBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(IndigoBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/jiocinema/JioCinemaBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/jiocinema/JioCinemaBL.java
@@ -5,13 +5,14 @@ import com.znsio.teswiz.entities.Direction;
 import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.screen.jiocinema.JioCinemaScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JioCinemaBL {
-    private static final Logger LOGGER = Logger.getLogger(JioCinemaBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(JioCinemaBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/AuthBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/AuthBL.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.jiomeet.SignInScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import java.util.Map;
@@ -13,7 +14,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AuthBL {
-    private static final Logger LOGGER = Logger.getLogger(AuthBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AuthBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/InAMeetingBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/InAMeetingBL.java
@@ -5,13 +5,14 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class InAMeetingBL {
-    private static final Logger LOGGER = Logger.getLogger(InAMeetingBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(InAMeetingBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/JoinAMeetingBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/JoinAMeetingBL.java
@@ -5,13 +5,14 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.jiomeet.SignInScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JoinAMeetingBL {
-    private static final Logger LOGGER = Logger.getLogger(JoinAMeetingBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(JoinAMeetingBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/LandingBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/jiomeet/LandingBL.java
@@ -6,13 +6,14 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
 import com.znsio.teswiz.screen.jiomeet.LandingScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LandingBL {
-    private static final Logger LOGGER = Logger.getLogger(LandingBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(LandingBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/notepad/NotepadBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/notepad/NotepadBL.java
@@ -6,11 +6,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.ScreenShotScreen;
 import com.znsio.teswiz.screen.notepad.NotepadScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class NotepadBL {
-    private static final Logger LOGGER = Logger.getLogger(NotepadBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(NotepadBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/restUser/JsonPlaceHolderBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/restUser/JsonPlaceHolderBL.java
@@ -6,13 +6,14 @@ import com.znsio.teswiz.services.UnirestService;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class JsonPlaceHolderBL {
 
-    private static final Logger LOGGER = Logger.getLogger(WeatherAPIBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(WeatherAPIBL.class.getName());
     private final Map<String, Object> testData = Runner.getTestDataAsMap("RestUser_API");
     private final String base_URL = testData.get("url").toString();
 

--- a/src/test/java/com/znsio/teswiz/businessLayer/search/SearchBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/search/SearchBL.java
@@ -5,11 +5,12 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.ScreenShotScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class SearchBL {
-    private static final Logger LOGGER = Logger.getLogger(SearchBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(SearchBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/theapp/AppBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/theapp/AppBL.java
@@ -6,11 +6,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.theapp.AppLaunchScreen;
 import com.znsio.teswiz.screen.theapp.LoginScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class AppBL {
-    private static final Logger LOGGER = Logger.getLogger(AppBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AppBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/theapp/ClipboardBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/theapp/ClipboardBL.java
@@ -6,13 +6,14 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.theapp.AppLaunchScreen;
 import com.znsio.teswiz.screen.theapp.ClipboardDemoScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ClipboardBL {
-    private static final Logger LOGGER = Logger.getLogger(ClipboardBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(ClipboardBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/theapp/EchoBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/theapp/EchoBL.java
@@ -5,11 +5,12 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.theapp.AppLaunchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 public class EchoBL {
-    private static final Logger LOGGER = Logger.getLogger(EchoBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(EchoBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/theapp/FileUploadBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/theapp/FileUploadBL.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.screen.theapp.FileUploadScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 
 import java.util.Map;
@@ -13,7 +14,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FileUploadBL {
-    private static final Logger LOGGER = Logger.getLogger(FileUploadBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(FileUploadBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/vodqa/VodqaBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/vodqa/VodqaBL.java
@@ -7,14 +7,15 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.screen.vodqa.DragAndDropScreen;
 import com.znsio.teswiz.screen.vodqa.VodqaScreen;
 import com.znsio.teswiz.screen.vodqa.WebViewScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.assertj.core.api.SoftAssertions;
 import org.openqa.selenium.Dimension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class VodqaBL {
-    private static final Logger LOGGER = Logger.getLogger(VodqaBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(VodqaBL.class.getName());
     private final TestExecutionContext context;
     private final SoftAssertions softly;
     private final String currentUserPersona;

--- a/src/test/java/com/znsio/teswiz/businessLayer/weatherAPI/WeatherAPIBL.java
+++ b/src/test/java/com/znsio/teswiz/businessLayer/weatherAPI/WeatherAPIBL.java
@@ -5,13 +5,14 @@ import com.znsio.teswiz.services.UnirestService;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import java.util.HashMap;
 import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class WeatherAPIBL {
-    private static final Logger LOGGER = Logger.getLogger(WeatherAPIBL.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(WeatherAPIBL.class.getName());
     private final Map<String, Object> testData = Runner.getTestDataAsMap("Weather_API");
     private final String base_URL = testData.get("url").toString();
 

--- a/src/test/java/com/znsio/teswiz/runner/BrowserStackImageInjectionTest.java
+++ b/src/test/java/com/znsio/teswiz/runner/BrowserStackImageInjectionTest.java
@@ -1,7 +1,8 @@
 package com.znsio.teswiz.runner;
 
 import io.appium.java_client.android.AndroidDriver;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -15,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class BrowserStackImageInjectionTest {
     private static final String LOG_DIR = "./target/testLogs";
 
-    private static final Logger LOGGER = Logger.getLogger(
+    private static final Logger LOGGER = LogManager.getLogger(
             BrowserStackImageInjectionTest.class.getName());
 
     static AndroidDriver driver;

--- a/src/test/java/com/znsio/teswiz/screen/ScreenShotScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/ScreenShotScreen.java
@@ -9,11 +9,12 @@ import com.znsio.teswiz.screen.android.ScreenShotScreenAndroid;
 import com.znsio.teswiz.screen.web.ScreenShotScreenWeb;
 import com.znsio.teswiz.screen.windows.ScreenShotScreenWindows;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class ScreenShotScreen {
     private static final String SCREEN_NAME = ScreenShotScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static ScreenShotScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/ajio/CartScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/ajio/CartScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.ajio.CartScreenAndroid;
 import com.znsio.teswiz.screen.ios.ajio.CartScreenIOS;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class CartScreen {
     private static final String SCREEN_NAME = CartScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static CartScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/ajio/HomeScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/ajio/HomeScreen.java
@@ -8,7 +8,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.ajio.HomeScreenAndroid;
 import com.znsio.teswiz.screen.ios.ajio.HomeScreenIOS;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Map;
 
@@ -16,7 +17,7 @@ import static com.znsio.teswiz.entities.Platform.iOS;
 
 public abstract class HomeScreen {
     private static final String SCREEN_NAME = HomeScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static HomeScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/ajio/ProductScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/ajio/ProductScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.ajio.ProductScreenAndroid;
 import com.znsio.teswiz.screen.ios.ajio.ProductScreenIOS;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class ProductScreen {
     private static final String SCREEN_NAME = ProductScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static ProductScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/ajio/SearchScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/ajio/SearchScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.ajio.SearchScreenAndroid;
 import com.znsio.teswiz.screen.ios.ajio.SearchScreenIOS;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class SearchScreen {
     private static final String SCREEN_NAME = SearchScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static SearchScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/android/ajio/CartScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/ajio/CartScreenAndroid.java
@@ -3,14 +3,15 @@ package com.znsio.teswiz.screen.android.ajio;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.CartScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 public class CartScreenAndroid
         extends CartScreen {
     private static final String SCREEN_NAME = CartScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byProductTitleId = By.id("com.ril.ajio:id/productTitle");
     private final Driver driver;
     private final Visual visually;

--- a/src/test/java/com/znsio/teswiz/screen/android/ajio/HomeScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/ajio/HomeScreenAndroid.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.HomeScreen;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
 import com.znsio.teswiz.screen.ajio.SearchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 import java.util.Map;
@@ -13,7 +14,7 @@ import java.util.Map;
 public class HomeScreenAndroid
         extends HomeScreen {
     private static final String SCREEN_NAME = HomeScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byStartSearchBoxId = By.id("com.ril.ajio:id/llpsTvSearch");
     private static final By byUploadPhotoButtonId = By.id("com.ril.ajio:id/layout_select_photo");
     private static final By byImageDirectoryXpath = By.xpath(

--- a/src/test/java/com/znsio/teswiz/screen/android/ajio/ProductScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/ajio/ProductScreenAndroid.java
@@ -7,14 +7,15 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.CartScreen;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 public class ProductScreenAndroid
         extends ProductScreen {
     private static final String SCREEN_NAME = ProductScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byProductNameId = By.id("com.ril.ajio:id/product_name");
     private static final By byAddToCartButtonId = By.id("com.ril.ajio:id/add_to_cart_tv");
     private static final By byViewBagButtonXpath = By.xpath(

--- a/src/test/java/com/znsio/teswiz/screen/android/ajio/SearchScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/ajio/SearchScreenAndroid.java
@@ -4,7 +4,8 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
 import com.znsio.teswiz.screen.ajio.SearchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -13,7 +14,7 @@ import java.util.List;
 public class SearchScreenAndroid
         extends SearchScreen {
     private static final String SCREEN_NAME = SearchScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byResultsId = By.id("com.ril.ajio:id/tv_count_plp_header_is");
     private static final By byProductId = By.id("com.ril.ajio:id/plp_row_product_iv");
     private static final By byProductListTitleId = By.id("com.ril.ajio:id/toolbar_title_tv");

--- a/src/test/java/com/znsio/teswiz/screen/android/autoscroll/AutoScrollScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/autoscroll/AutoScrollScreenAndroid.java
@@ -6,14 +6,15 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.autoscroll.AutoScrollScreen;
 import io.appium.java_client.AppiumBy;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 
 public class AutoScrollScreenAndroid extends AutoScrollScreen {
     private static final String SCREEN_NAME = AutoScrollScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private final Driver driver;
     private final Visual visually;
     private final By byAddNewAppButton = AppiumBy.id("com.tafayor.autoscroll2:id/add");

--- a/src/test/java/com/znsio/teswiz/screen/android/confengine/ConfEngineLandingScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/confengine/ConfEngineLandingScreenAndroid.java
@@ -4,7 +4,8 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.confengine.ConfEngineLandingScreen;
 import io.appium.java_client.AppiumDriver;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 import java.util.Set;
@@ -12,7 +13,7 @@ import java.util.Set;
 public class ConfEngineLandingScreenAndroid
         extends ConfEngineLandingScreen {
     private static final String SCREEN_NAME = ConfEngineLandingScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private final Driver driver;
     private final Visual visually;

--- a/src/test/java/com/znsio/teswiz/screen/android/dineout/DineoutLandingScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/dineout/DineoutLandingScreenAndroid.java
@@ -3,7 +3,8 @@ package com.znsio.teswiz.screen.android.dineout;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.dineout.DineoutLandingScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
@@ -11,7 +12,7 @@ import org.openqa.selenium.WebElement;
 public class DineoutLandingScreenAndroid
         extends DineoutLandingScreen {
     private static final String SCREEN_NAME = DineoutLandingScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private final Driver driver;
     private final Visual visually;

--- a/src/test/java/com/znsio/teswiz/screen/android/googlesearch/GoogleSearchLandingScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/googlesearch/GoogleSearchLandingScreenAndroid.java
@@ -6,14 +6,15 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.googlesearch.GoogleSearchLandingScreen;
 import com.znsio.teswiz.screen.googlesearch.GoogleSearchResultsScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
 public class GoogleSearchLandingScreenAndroid extends GoogleSearchLandingScreen {
     private static final String URL = "https://google.com";
     private static final String SCREEN_NAME = GoogleSearchLandingScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By SEARCH_INPUT = By.name("q");
 
     private final Driver driver;

--- a/src/test/java/com/znsio/teswiz/screen/android/indigo/IndigoFlightSearchResultsScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/indigo/IndigoFlightSearchResultsScreenAndroid.java
@@ -3,14 +3,15 @@ package com.znsio.teswiz.screen.android.indigo;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.indigo.IndigoFlightSearchResultsScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class IndigoFlightSearchResultsScreenAndroid
         extends IndigoFlightSearchResultsScreen {
     private static final String SCREEN_NAME =
             IndigoFlightSearchResultsScreenAndroid.class.getSimpleName();
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private final Driver driver;
     private final Visual visually;
 

--- a/src/test/java/com/znsio/teswiz/screen/android/indigo/IndigoGiftVouchersScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/indigo/IndigoGiftVouchersScreenAndroid.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.indigo.IndigoGiftVouchersScreen;
 import io.appium.java_client.AppiumDriver;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 import java.util.Set;
@@ -13,7 +14,7 @@ import java.util.Set;
 public class IndigoGiftVouchersScreenAndroid
         extends IndigoGiftVouchersScreen {
     private static final String SCREEN_NAME = IndigoGiftVouchersScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private static final By bySelectDenominationDropdownXpath = By.xpath(
             "//android.widget.TextView[@text='Select Denomination']");

--- a/src/test/java/com/znsio/teswiz/screen/android/indigo/IndigoHomeScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/indigo/IndigoHomeScreenAndroid.java
@@ -6,14 +6,15 @@ import com.znsio.teswiz.screen.indigo.IndigoFlightSearchResultsScreen;
 import com.znsio.teswiz.screen.indigo.IndigoGiftVouchersScreen;
 import com.znsio.teswiz.screen.indigo.IndigoHomeScreen;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 public class IndigoHomeScreenAndroid
         extends IndigoHomeScreen {
     private static final String SCREEN_NAME = IndigoHomeScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private static final By byContinueAsGuestId = By.id("in.goindigo.android:id/button_as_guest");
     private static final By byGiftVoucherXpath = By.xpath(

--- a/src/test/java/com/znsio/teswiz/screen/android/jiocinema/JioCinemaScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/jiocinema/JioCinemaScreenAndroid.java
@@ -7,12 +7,13 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.jiocinema.JioCinemaScreen;
 import io.appium.java_client.AppiumBy;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 public class JioCinemaScreenAndroid extends JioCinemaScreen {
-    private static final Logger LOGGER = Logger.getLogger(JioCinemaScreenAndroid.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(JioCinemaScreenAndroid.class.getName());
     private final Driver driver;
     private final Visual visually;
     private final String SCREEN_NAME = JioCinemaScreenAndroid.class.getSimpleName();

--- a/src/test/java/com/znsio/teswiz/screen/android/jiomeet/InAMeetingScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/jiomeet/InAMeetingScreenAndroid.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.exceptions.jiomeet.InAMeetingException;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -14,7 +15,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class InAMeetingScreenAndroid
         extends InAMeetingScreen {
     private static final String SCREEN_NAME = InAMeetingScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byMicStatusId = By.id("com.jio.rilconferences:id/mic_status_label");
     private static final By byMeetingId = By.id("com.jio.rilconferences:id/caller_number");
     private static final By byMeetingPasswordId = By.id(

--- a/src/test/java/com/znsio/teswiz/screen/android/jiomeet/LandingScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/jiomeet/LandingScreenAndroid.java
@@ -4,7 +4,8 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
 import com.znsio.teswiz.screen.jiomeet.LandingScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 import static com.znsio.teswiz.tools.Wait.waitFor;
@@ -12,7 +13,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class LandingScreenAndroid
         extends LandingScreen {
     private static final String SCREEN_NAME = LandingScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byWelcomeMessageId = By.id("com.jio.rilconferences:id/textUserName");
     private static final By byStartInstantMeetingId = By.id(
             "com.jio.rilconferences:id/buttonStartMeeting");

--- a/src/test/java/com/znsio/teswiz/screen/android/jiomeet/SignInScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/jiomeet/SignInScreenAndroid.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
 import com.znsio.teswiz.screen.jiomeet.LandingScreen;
 import com.znsio.teswiz.screen.jiomeet.SignInScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -14,7 +15,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class SignInScreenAndroid
         extends SignInScreen {
     private static final String SCREEN_NAME = SignInScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By bySignInId = By.id("com.jio.rilconferences:id/signIn");
     private static final By byUserNameId = By.id("com.jio.rilconferences:id/edit_mobile_number");
     private static final By byProceedButtonId = By.id("com.jio.rilconferences:id/btn_otp_next");

--- a/src/test/java/com/znsio/teswiz/screen/android/theapp/AppLaunchScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/theapp/AppLaunchScreenAndroid.java
@@ -6,13 +6,14 @@ import com.znsio.teswiz.screen.theapp.AppLaunchScreen;
 import com.znsio.teswiz.screen.theapp.ClipboardDemoScreen;
 import com.znsio.teswiz.screen.theapp.EchoScreen;
 import com.znsio.teswiz.screen.theapp.LoginScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 public class AppLaunchScreenAndroid
         extends AppLaunchScreen {
     private static final String SCREEN_NAME = AppLaunchScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byGoBackToHomeScreenButtonXpath = By.xpath(
             "//android.widget.ImageButton[@content-desc=\"Navigate Up\"]");
     private static final By byEchoMessageXpath = By.xpath(

--- a/src/test/java/com/znsio/teswiz/screen/android/theapp/ClipboardDemoScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/theapp/ClipboardDemoScreenAndroid.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.theapp.ClipboardDemoScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.WebElement;
 
 import static com.znsio.teswiz.tools.Wait.waitFor;
@@ -13,7 +14,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class ClipboardDemoScreenAndroid
         extends ClipboardDemoScreen {
     private static final String SCREEN_NAME = ClipboardDemoScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private final Driver driver;
     private final Visual visually;
     private final String bySetClipboardTextByAccessibilityId = "setClipboardText";

--- a/src/test/java/com/znsio/teswiz/screen/android/vodqa/DragAndDropScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/vodqa/DragAndDropScreenAndroid.java
@@ -4,7 +4,8 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.vodqa.DragAndDropScreen;
 import io.appium.java_client.AppiumBy;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 public class DragAndDropScreenAndroid extends DragAndDropScreen {
@@ -12,7 +13,7 @@ public class DragAndDropScreenAndroid extends DragAndDropScreen {
     private final Driver driver;
     private final Visual visually;
     private static final String SCREEN_NAME = DragAndDropScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private final By byCircleDroppedAccessibilityId = AppiumBy.accessibilityId("success");
     private final By byDraggableObjectAccessibilityId = AppiumBy.accessibilityId("dragMe");
     private final By byDropZoneAccessibilityId = AppiumBy.accessibilityId("dropzone");

--- a/src/test/java/com/znsio/teswiz/screen/android/vodqa/NativeViewScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/vodqa/NativeViewScreenAndroid.java
@@ -4,14 +4,15 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.vodqa.NativeViewScreen;
 import io.appium.java_client.AppiumBy;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 public class NativeViewScreenAndroid extends NativeViewScreen {
     private final Driver driver;
     private final Visual visually;
     private static final String SCREEN_NAME = NativeViewScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     private static final By byNativeViewScreenHeaderXpath = AppiumBy.xpath("//android.widget.TextView[@text = 'Native View Demo']");
 

--- a/src/test/java/com/znsio/teswiz/screen/android/vodqa/VodqaScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/vodqa/VodqaScreenAndroid.java
@@ -10,7 +10,8 @@ import com.znsio.teswiz.screen.vodqa.VodqaScreen;
 import com.znsio.teswiz.screen.vodqa.WebViewScreen;
 import com.znsio.teswiz.tools.cmd.CommandLineExecutor;
 import io.appium.java_client.AppiumBy;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
@@ -20,7 +21,7 @@ public class VodqaScreenAndroid extends VodqaScreen {
     private final Driver driver;
     private final Visual visually;
     private final String SCREEN_NAME = VodqaScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(VodqaScreenAndroid.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(VodqaScreenAndroid.class.getName());
     private final By byLoginButton = AppiumBy.xpath("//android.view.ViewGroup[@content-desc='login']/android.widget.Button");
     private final By byVerticalSwipeViewGroup = AppiumBy.xpath("//android.view.ViewGroup[@content-desc='verticalSwipe']");
     private final By byCLanguageTextView = AppiumBy.xpath("//android.widget.TextView[@text=' C']");

--- a/src/test/java/com/znsio/teswiz/screen/android/vodqa/WebViewScreenAndroid.java
+++ b/src/test/java/com/znsio/teswiz/screen/android/vodqa/WebViewScreenAndroid.java
@@ -6,14 +6,15 @@ import com.znsio.teswiz.screen.vodqa.VodqaScreen;
 import com.znsio.teswiz.screen.vodqa.WebViewScreen;
 import io.appium.java_client.AppiumBy;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 public class WebViewScreenAndroid extends WebViewScreen {
     private final Driver driver;
     private final Visual visually;
     private static final String SCREEN_NAME = WebViewScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     private static final By byWebViewScreenHeaderXpath = AppiumBy.xpath("//android.widget.TextView[@text = 'Webview']");
     private static final By byLoginOptionWebviewXpath = By.xpath("//a[text()='login']");

--- a/src/test/java/com/znsio/teswiz/screen/autoscroll/AutoScrollScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/autoscroll/AutoScrollScreen.java
@@ -8,12 +8,13 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.autoscroll.AutoScrollScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class AutoScrollScreen {
 
     private static final String SCREEN_NAME = AutoScrollScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static AutoScrollScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/calculator/CalculatorScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/calculator/CalculatorScreen.java
@@ -7,11 +7,12 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.calculator.CalculatorScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class CalculatorScreen {
     private static final String SCREEN_NAME = CalculatorScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static CalculatorScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/calculator/NewCalculatorScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/calculator/NewCalculatorScreen.java
@@ -7,11 +7,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.calculator.NewCalculatorScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class NewCalculatorScreen {
     private static final String SCREEN_NAME = NewCalculatorScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static NewCalculatorScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/confengine/ConfEngineLandingScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/confengine/ConfEngineLandingScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.confengine.ConfEngineLandingScreenAndroid;
 import com.znsio.teswiz.screen.web.confengine.ConfEngineLandingScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class ConfEngineLandingScreen {
     private static final String SCREEN_NAME = ConfEngineLandingScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static ConfEngineLandingScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/dineout/DineoutLandingScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/dineout/DineoutLandingScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.dineout.DineoutLandingScreenAndroid;
 import com.znsio.teswiz.screen.web.dineout.DineoutLandingScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class DineoutLandingScreen {
     private static final String SCREEN_NAME = DineoutLandingScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static DineoutLandingScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/googlesearch/GoogleSearchLandingScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/googlesearch/GoogleSearchLandingScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.googlesearch.GoogleSearchLandingScreenAndroid;
 import com.znsio.teswiz.screen.web.googlesearch.GoogleSearchLandingScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class GoogleSearchLandingScreen {
     private static final String SCREEN_NAME = GoogleSearchLandingScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static GoogleSearchLandingScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/googlesearch/GoogleSearchResultsScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/googlesearch/GoogleSearchResultsScreen.java
@@ -8,13 +8,14 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.googlesearch.GoogleSearchResultsScreenAndroid;
 import com.znsio.teswiz.screen.web.googlesearch.GoogleSearchResultsScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.List;
 
 public abstract class GoogleSearchResultsScreen {
     private static final String SCREEN_NAME = GoogleSearchResultsScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static GoogleSearchResultsScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/helloWorld/HelloWorldScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/helloWorld/HelloWorldScreen.java
@@ -7,11 +7,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ios.helloWorld.HelloWorldScreenIOS;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class HelloWorldScreen {
     private static final String SCREEN_NAME = HelloWorldScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static HelloWorldScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/indigo/IndigoFlightSearchResultsScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/indigo/IndigoFlightSearchResultsScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.indigo.IndigoFlightSearchResultsScreenAndroid;
 import com.znsio.teswiz.screen.web.indigo.IndigoFlightSearchResultsScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class IndigoFlightSearchResultsScreen {
     private static final String SCREEN_NAME = IndigoFlightSearchResultsScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static IndigoFlightSearchResultsScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/indigo/IndigoGiftVouchersScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/indigo/IndigoGiftVouchersScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.indigo.IndigoGiftVouchersScreenAndroid;
 import com.znsio.teswiz.screen.web.indigo.IndigoGiftVouchersScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class IndigoGiftVouchersScreen {
     private static final String SCREEN_NAME = IndigoGiftVouchersScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static IndigoGiftVouchersScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/indigo/IndigoHomeScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/indigo/IndigoHomeScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.indigo.IndigoHomeScreenAndroid;
 import com.znsio.teswiz.screen.web.indigo.IndigoHomeScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class IndigoHomeScreen {
     private static final String SCREEN_NAME = IndigoHomeScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static IndigoHomeScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/ios/ajio/CartScreenIOS.java
+++ b/src/test/java/com/znsio/teswiz/screen/ios/ajio/CartScreenIOS.java
@@ -4,7 +4,8 @@ import com.applitools.eyes.appium.Target;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.CartScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -13,7 +14,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class CartScreenIOS
         extends CartScreen {
     private static final String SCREEN_NAME = CartScreenIOS.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byProductTitleId = By.id("cart_cartController_cartCell_productNameLabel");
     private static final By byWishlistPopUp = By.id("OK");
     private final Driver driver;

--- a/src/test/java/com/znsio/teswiz/screen/ios/ajio/HomeScreenIOS.java
+++ b/src/test/java/com/znsio/teswiz/screen/ios/ajio/HomeScreenIOS.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.HomeScreen;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
 import com.znsio.teswiz.screen.ajio.SearchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -16,7 +17,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class HomeScreenIOS
         extends HomeScreen {
     private static final String SCREEN_NAME = HomeScreenIOS.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byStartSearchBoxId = By.id("Home_Search_Label");
     private static final By byUploadPhotoButtonId = By.id("Upload a Photo");
     private static final By byImageId = By.xpath("//XCUIElementTypeImage[contains(@name,'Photo, October 10')]");

--- a/src/test/java/com/znsio/teswiz/screen/ios/ajio/ProductScreenIOS.java
+++ b/src/test/java/com/znsio/teswiz/screen/ios/ajio/ProductScreenIOS.java
@@ -4,7 +4,8 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.CartScreen;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -15,7 +16,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class ProductScreenIOS
         extends ProductScreen {
     private static final String SCREEN_NAME = ProductScreenIOS.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byProductNameId = By.id("V2Pdp_brand_ProductName");
     private static final By byAddToCartButtonId = By.id("Add To Bag");
     private static final By byViewBagButtonId = By.id("V2PDP_BottomFloatingView_ATC");

--- a/src/test/java/com/znsio/teswiz/screen/ios/ajio/SearchScreenIOS.java
+++ b/src/test/java/com/znsio/teswiz/screen/ios/ajio/SearchScreenIOS.java
@@ -4,13 +4,14 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.ajio.ProductScreen;
 import com.znsio.teswiz.screen.ajio.SearchScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 public class SearchScreenIOS
         extends SearchScreen {
     private static final String SCREEN_NAME = SearchScreenIOS.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byResultsXpath = By.xpath("//XCUIElementTypeStaticText[@name[contains(.,'Products')]]");
     private static final By byProductXpath = By.xpath("(//XCUIElementTypeButton[@name=\"view_similar_button\"])[1]/preceding-sibling::XCUIElementTypeImage");
     private static final By byProductListingPageHeaderId = By.id("headerTitle_NavigationBar");

--- a/src/test/java/com/znsio/teswiz/screen/jiocinema/JioCinemaScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/jiocinema/JioCinemaScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.jiocinema.JioCinemaScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class JioCinemaScreen {
     private static final String SCREEN_NAME = JioCinemaScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static JioCinemaScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/jiomeet/InAMeetingScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/jiomeet/InAMeetingScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.jiomeet.InAMeetingScreenAndroid;
 import com.znsio.teswiz.screen.web.jiomeet.InAMeetingScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class InAMeetingScreen {
     private static final String SCREEN_NAME = InAMeetingScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static InAMeetingScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/jiomeet/LandingScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/jiomeet/LandingScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.jiomeet.LandingScreenAndroid;
 import com.znsio.teswiz.screen.web.jiomeet.LandingScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class LandingScreen {
     private static final String SCREEN_NAME = LandingScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static LandingScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/jiomeet/SignInScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/jiomeet/SignInScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.jiomeet.SignInScreenAndroid;
 import com.znsio.teswiz.screen.web.jiomeet.SignInScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class SignInScreen {
     private static final String SCREEN_NAME = SignInScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static SignInScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/notepad/NotepadScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/notepad/NotepadScreen.java
@@ -7,11 +7,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.windows.notepad.NotepadScreenWindows;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class NotepadScreen {
     private static final String SCREEN_NAME = NotepadScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static NotepadScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/theapp/AppLaunchScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/theapp/AppLaunchScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.theapp.AppLaunchScreenAndroid;
 import com.znsio.teswiz.screen.web.theapp.AppLaunchScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class AppLaunchScreen {
     private static final String SCREEN_NAME = AppLaunchScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static AppLaunchScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/theapp/ClipboardDemoScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/theapp/ClipboardDemoScreen.java
@@ -7,11 +7,12 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.theapp.ClipboardDemoScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class ClipboardDemoScreen {
     private static final String SCREEN_NAME = ClipboardDemoScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static ClipboardDemoScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/theapp/EchoScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/theapp/EchoScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.theapp.EchoScreenAndroid;
 import com.znsio.teswiz.screen.web.theapp.EchoScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class EchoScreen {
     private static final String SCREEN_NAME = EchoScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static EchoScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/theapp/FileUploadScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/theapp/FileUploadScreen.java
@@ -7,13 +7,14 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.web.theapp.FileUploadScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Map;
 
 public abstract class FileUploadScreen {
     private static final String SCREEN_NAME = FileUploadScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static FileUploadScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/theapp/LoginScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/theapp/LoginScreen.java
@@ -8,11 +8,12 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.theapp.LoginScreenAndroid;
 import com.znsio.teswiz.screen.web.theapp.LoginScreenWeb;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class LoginScreen {
     private static final String SCREEN_NAME = LoginScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static LoginScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/vodqa/DragAndDropScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/vodqa/DragAndDropScreen.java
@@ -7,12 +7,13 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.vodqa.DragAndDropScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class DragAndDropScreen {
 
     private static final String SCREEN_NAME = DragAndDropScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static DragAndDropScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/vodqa/NativeViewScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/vodqa/NativeViewScreen.java
@@ -7,11 +7,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.vodqa.NativeViewScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class NativeViewScreen {
     private static final String SCREEN_NAME = NativeViewScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static NativeViewScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/vodqa/VodqaScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/vodqa/VodqaScreen.java
@@ -7,12 +7,13 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.vodqa.VodqaScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.Dimension;
 
 public abstract class VodqaScreen {
     private static final String SCREEN_NAME = VodqaScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static VodqaScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/vodqa/WebViewScreen.java
+++ b/src/test/java/com/znsio/teswiz/screen/vodqa/WebViewScreen.java
@@ -7,11 +7,12 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.vodqa.WebViewScreenAndroid;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public abstract class WebViewScreen {
     private static final String SCREEN_NAME = WebViewScreen.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
 
     public static WebViewScreen get() {
         Driver driver = Drivers.getDriverForCurrentUser(Thread.currentThread().getId());

--- a/src/test/java/com/znsio/teswiz/screen/web/confengine/ConfEngineLandingScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/confengine/ConfEngineLandingScreenWeb.java
@@ -4,12 +4,13 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.confengine.ConfEngineLandingScreen;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class ConfEngineLandingScreenWeb
         extends ConfEngineLandingScreen {
     private static final String SCREEN_NAME = ConfEngineLandingScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private final Driver driver;
     private final Visual visually;

--- a/src/test/java/com/znsio/teswiz/screen/web/dineout/DineoutLandingScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/dineout/DineoutLandingScreenWeb.java
@@ -4,7 +4,8 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.dineout.DineoutLandingScreen;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
@@ -12,7 +13,7 @@ public class DineoutLandingScreenWeb
         extends DineoutLandingScreen {
 
     private static final String SCREEN_NAME = DineoutLandingScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private final Driver driver;
     private final Visual visually;

--- a/src/test/java/com/znsio/teswiz/screen/web/googlesearch/GoogleSearchLandingScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/googlesearch/GoogleSearchLandingScreenWeb.java
@@ -6,14 +6,15 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.googlesearch.GoogleSearchLandingScreen;
 import com.znsio.teswiz.screen.googlesearch.GoogleSearchResultsScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 
 public class GoogleSearchLandingScreenWeb extends GoogleSearchLandingScreen {
     private static final String URL = "https://google.com";
     private static final String SCREEN_NAME = GoogleSearchLandingScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By SEARCH_INPUT = By.name("q");
 
     private final Driver driver;

--- a/src/test/java/com/znsio/teswiz/screen/web/googlesearch/GoogleSearchResultsScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/googlesearch/GoogleSearchResultsScreenWeb.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.googlesearch.GoogleSearchResultsScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 import java.util.List;
@@ -13,7 +14,7 @@ import java.util.stream.Collectors;
 
 public class GoogleSearchResultsScreenWeb extends GoogleSearchResultsScreen {
     private static final String SCREEN_NAME = GoogleSearchResultsScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private final Driver driver;
     private final Visual visually;
     private final TestExecutionContext context;

--- a/src/test/java/com/znsio/teswiz/screen/web/indigo/IndigoFlightSearchResultsScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/indigo/IndigoFlightSearchResultsScreenWeb.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.indigo.IndigoFlightSearchResultsScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 
@@ -13,7 +14,7 @@ public class IndigoFlightSearchResultsScreenWeb
         extends IndigoFlightSearchResultsScreen {
     private static final String SCREEN_NAME =
             IndigoFlightSearchResultsScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private static final By byBackToSearchResultsLinkXpath = By.xpath(
             "//div[@class='bck-to-search']");

--- a/src/test/java/com/znsio/teswiz/screen/web/indigo/IndigoGiftVouchersScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/indigo/IndigoGiftVouchersScreenWeb.java
@@ -5,7 +5,8 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.indigo.IndigoGiftVouchersScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -16,7 +17,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class IndigoGiftVouchersScreenWeb
         extends IndigoGiftVouchersScreen {
     private static final String SCREEN_NAME = IndigoGiftVouchersScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private static final By bySelectedVoucherValueDropdownId = By.id("SelectedVoucherValue");
     private static final By bySelectedVoucherQuantityDropdownId = By.id("SelectedVoucherQuantity");

--- a/src/test/java/com/znsio/teswiz/screen/web/indigo/IndigoHomeScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/indigo/IndigoHomeScreenWeb.java
@@ -7,7 +7,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.indigo.IndigoFlightSearchResultsScreen;
 import com.znsio.teswiz.screen.indigo.IndigoGiftVouchersScreen;
 import com.znsio.teswiz.screen.indigo.IndigoHomeScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -18,7 +19,7 @@ import static com.znsio.teswiz.tools.Wait.waitFor;
 public class IndigoHomeScreenWeb
         extends IndigoHomeScreen {
     private static final String SCREEN_NAME = IndigoHomeScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private static final By byFromXpath = By.xpath("//input[@placeholder='From']");
     private static final By byToXpath = By.xpath("//input[@placeholder='To']");

--- a/src/test/java/com/znsio/teswiz/screen/web/jiomeet/InAMeetingScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/jiomeet/InAMeetingScreenWeb.java
@@ -8,7 +8,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
 import com.znsio.teswiz.tools.ReportPortalLogger;
 import org.apache.commons.lang.NotImplementedException;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -18,7 +19,7 @@ import org.openqa.selenium.interactions.Actions;
 public class InAMeetingScreenWeb
         extends InAMeetingScreen {
     private static final String SCREEN_NAME = InAMeetingScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private static final By byMeetingInfoIconXpath = By.xpath("//div[@class='icon pointer']");
     private static final By byMicLabelXpath = By.xpath("//div[contains(@class, 'mic-section')]//img");

--- a/src/test/java/com/znsio/teswiz/screen/web/jiomeet/LandingScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/jiomeet/LandingScreenWeb.java
@@ -5,14 +5,15 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.android.jiomeet.LandingScreenAndroid;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
 import com.znsio.teswiz.screen.jiomeet.LandingScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 
 public class LandingScreenWeb
         extends LandingScreen {
     private static final String SCREEN_NAME = LandingScreenAndroid.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final By byHeadingXpath = By.xpath("//h3[contains(@class,'heading')]");
     private static final By byWelcomeTextDescriptionXpath = By.xpath("//p[@class='desc']");
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";

--- a/src/test/java/com/znsio/teswiz/screen/web/jiomeet/SignInScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/jiomeet/SignInScreenWeb.java
@@ -6,7 +6,8 @@ import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.jiomeet.InAMeetingScreen;
 import com.znsio.teswiz.screen.jiomeet.LandingScreen;
 import com.znsio.teswiz.screen.jiomeet.SignInScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebElement;
@@ -14,7 +15,7 @@ import org.openqa.selenium.WebElement;
 public class SignInScreenWeb
         extends SignInScreen {
     private static final String SCREEN_NAME = SignInScreenWeb.class.getSimpleName();
-    private static final Logger LOGGER = Logger.getLogger(SCREEN_NAME);
+    private static final Logger LOGGER = LogManager.getLogger(SCREEN_NAME);
     private static final String NOT_YET_IMPLEMENTED = " not yet implemented";
     private static final By byEnterMeetingId = By.id("meetingId");
     private static final By byJoinMeetingButtonId = By.id("headerJoinMeetingButton");

--- a/src/test/java/com/znsio/teswiz/screen/web/theapp/AppLaunchScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/theapp/AppLaunchScreenWeb.java
@@ -6,13 +6,14 @@ import com.znsio.teswiz.screen.theapp.AppLaunchScreen;
 import com.znsio.teswiz.screen.theapp.ClipboardDemoScreen;
 import com.znsio.teswiz.screen.theapp.EchoScreen;
 import com.znsio.teswiz.screen.theapp.LoginScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 public class AppLaunchScreenWeb
         extends AppLaunchScreen {
     private static final String NOT_YET_IMPLEMENTED = "NOT_YET_IMPLEMENTED";
-    private static final Logger LOGGER = Logger.getLogger(AppLaunchScreenWeb.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AppLaunchScreenWeb.class.getName());
     private static final By loginFormLinkText = By.linkText("Form Authentication");
     private final Driver driver;
     private final Visual visually;

--- a/src/test/java/com/znsio/teswiz/screen/web/theapp/EchoScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/theapp/EchoScreenWeb.java
@@ -3,12 +3,13 @@ package com.znsio.teswiz.screen.web.theapp;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.theapp.EchoScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class EchoScreenWeb
         extends EchoScreen {
     private static final String NOT_YET_IMPLEMENTED = "NOT_YET_IMPLEMENTED";
-    private static final Logger LOGGER = Logger.getLogger(EchoScreenWeb.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(EchoScreenWeb.class.getName());
     private final Driver driver;
     private final Visual visually;
     private final String SCREEN_NAME = EchoScreenWeb.class.getSimpleName();

--- a/src/test/java/com/znsio/teswiz/screen/web/theapp/FileUploadScreenWeb.java
+++ b/src/test/java/com/znsio/teswiz/screen/web/theapp/FileUploadScreenWeb.java
@@ -3,14 +3,15 @@ package com.znsio.teswiz.screen.web.theapp;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.theapp.FileUploadScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 import java.util.Map;
 
 public class FileUploadScreenWeb
         extends FileUploadScreen {
-    private static final Logger LOGGER = Logger.getLogger(FileUploadScreenWeb.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(FileUploadScreenWeb.class.getName());
     private final Driver driver;
     private final Visual visually;
     private final String SCREEN_NAME = FileUploadScreenWeb.class.getSimpleName();

--- a/src/test/java/com/znsio/teswiz/screen/windows/notepad/NotepadScreenWindows.java
+++ b/src/test/java/com/znsio/teswiz/screen/windows/notepad/NotepadScreenWindows.java
@@ -3,13 +3,13 @@ package com.znsio.teswiz.screen.windows.notepad;
 import com.znsio.teswiz.runner.Driver;
 import com.znsio.teswiz.runner.Visual;
 import com.znsio.teswiz.screen.notepad.NotepadScreen;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.openqa.selenium.By;
 
 public class NotepadScreenWindows
         extends NotepadScreen {
-    private static final org.apache.log4j.Logger LOGGER = Logger.getLogger(
-            NotepadScreenWindows.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(NotepadScreenWindows.class.getName());
     private static final By byEditorName = By.name("Text Editor");
     private final Driver driver;
     private final Visual visually;

--- a/src/test/java/com/znsio/teswiz/services/UnirestService.java
+++ b/src/test/java/com/znsio/teswiz/services/UnirestService.java
@@ -3,14 +3,15 @@ package com.znsio.teswiz.services;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
 import kong.unirest.Unirest;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class UnirestService {
 
-    private static final Logger LOGGER = Logger.getLogger(UnirestService.class);
+    private static final Logger LOGGER = LogManager.getLogger(UnirestService.class);
     private static final Unirest unirest = new Unirest();
 
     private static Unirest getUnirestObj(){

--- a/src/test/java/com/znsio/teswiz/steps/AjioSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/AjioSteps.java
@@ -12,10 +12,11 @@ import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class AjioSteps {
-    private static final Logger LOGGER = Logger.getLogger(AjioSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AjioSteps.class.getName());
     private final TestExecutionContext context;
 
     public AjioSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/AppLaunchSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/AppLaunchSteps.java
@@ -8,13 +8,14 @@ import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.runner.Runner;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.json.JSONObject;
 
 import java.util.Locale;
 
 public class AppLaunchSteps {
-    private static final Logger LOGGER = Logger.getLogger(AppLaunchSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AppLaunchSteps.class.getName());
     private final TestExecutionContext context;
 
     public AppLaunchSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/AutoScrollSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/AutoScrollSteps.java
@@ -9,10 +9,11 @@ import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.runner.Runner;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class AutoScrollSteps {
-    private static final Logger LOGGER = Logger.getLogger(AutoScrollSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(AutoScrollSteps.class.getName());
     private final TestExecutionContext context;
 
     public AutoScrollSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/CalculatorSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/CalculatorSteps.java
@@ -11,12 +11,13 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import static com.znsio.teswiz.tools.Wait.waitFor;
 
 public class CalculatorSteps {
-    private static final Logger LOGGER = Logger.getLogger(CalculatorSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(CalculatorSteps.class.getName());
     private final TestExecutionContext context;
 
     public CalculatorSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/ConfEngineSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/ConfEngineSteps.java
@@ -7,10 +7,11 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import io.cucumber.java.en.Given;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class ConfEngineSteps {
-    private static final Logger LOGGER = Logger.getLogger(ConfEngineSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(ConfEngineSteps.class.getName());
     private final TestExecutionContext context;
 
     public ConfEngineSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/CryptoAPISteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/CryptoAPISteps.java
@@ -7,12 +7,13 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import kong.unirest.HttpResponse;
 import kong.unirest.JsonNode;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class CryptoAPISteps {
 
     private HttpResponse<JsonNode> jsonResponse;
-    private static final Logger LOGGER = Logger.getLogger(CryptoAPISteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(CryptoAPISteps.class.getName());
     private final TestExecutionContext context;
 
     public CryptoAPISteps() {

--- a/src/test/java/com/znsio/teswiz/steps/DineoutSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/DineoutSteps.java
@@ -8,10 +8,11 @@ import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class DineoutSteps {
-    private static final Logger LOGGER = Logger.getLogger(IndigoSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(IndigoSteps.class.getName());
     private final TestExecutionContext context;
 
     public DineoutSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/GoogleSearchSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/GoogleSearchSteps.java
@@ -8,12 +8,13 @@ import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.runner.Runner;
 import io.cucumber.java.en.Given;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Locale;
 
 public class GoogleSearchSteps {
-    private static final Logger LOGGER = Logger.getLogger(GoogleSearchSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(GoogleSearchSteps.class.getName());
     private final TestExecutionContext context;
 
     public GoogleSearchSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/HelloWorldSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/HelloWorldSteps.java
@@ -11,10 +11,11 @@ import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.runner.Runner;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class HelloWorldSteps {
-    private static final Logger LOGGER = Logger.getLogger(HelloWorldSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(HelloWorldSteps.class.getName());
     private final TestExecutionContext context;
 
     public HelloWorldSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/IndigoSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/IndigoSteps.java
@@ -8,10 +8,11 @@ import com.znsio.teswiz.runner.Runner;
 import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import io.cucumber.java.en.Given;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class IndigoSteps {
-    private static final Logger LOGGER = Logger.getLogger(IndigoSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(IndigoSteps.class.getName());
     private final TestExecutionContext context;
 
     public IndigoSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/JioCinemaSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/JioCinemaSteps.java
@@ -10,10 +10,11 @@ import com.znsio.teswiz.runner.Runner;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class JioCinemaSteps {
-    private static final Logger LOGGER = Logger.getLogger(JioCinemaSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(JioCinemaSteps.class.getName());
     private final TestExecutionContext context;
 
     public JioCinemaSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/JioMeetSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/JioMeetSteps.java
@@ -15,13 +15,14 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Locale;
 import java.util.Map;
 
 public class JioMeetSteps {
-    private static final Logger LOGGER = Logger.getLogger(JioMeetSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(JioMeetSteps.class.getName());
     private final TestExecutionContext context;
 
     public JioMeetSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/JsonPlaceHolderSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/JsonPlaceHolderSteps.java
@@ -8,10 +8,11 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import kong.unirest.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class JsonPlaceHolderSteps {
-    private static final Logger LOGGER = Logger.getLogger(WeatherAPISteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(WeatherAPISteps.class.getName());
     private final TestExecutionContext context;
     private JSONObject jsonObject;
     private int statusCode;

--- a/src/test/java/com/znsio/teswiz/steps/RunTestCukes.java
+++ b/src/test/java/com/znsio/teswiz/steps/RunTestCukes.java
@@ -12,12 +12,13 @@ import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
 import io.cucumber.testng.AbstractTestNGCucumberTests;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.testng.annotations.DataProvider;
 
 public class RunTestCukes
         extends AbstractTestNGCucumberTests {
-    private static final Logger LOGGER = Logger.getLogger(RunTestCukes.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(RunTestCukes.class.getName());
     private final TestExecutionContext context;
 
     public RunTestCukes() {

--- a/src/test/java/com/znsio/teswiz/steps/SearchSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/SearchSteps.java
@@ -6,10 +6,11 @@ import com.znsio.teswiz.businessLayer.search.SearchBL;
 import com.znsio.teswiz.entities.Platform;
 import com.znsio.teswiz.runner.Runner;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class SearchSteps {
-    private static final Logger LOGGER = Logger.getLogger(SearchSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(SearchSteps.class.getName());
     private final TestExecutionContext context;
 
     public SearchSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/TheAppSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/TheAppSteps.java
@@ -16,10 +16,11 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class TheAppSteps {
-    private static final Logger LOGGER = Logger.getLogger(TheAppSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(TheAppSteps.class.getName());
     private final TestExecutionContext context;
 
     public TheAppSteps() {

--- a/src/test/java/com/znsio/teswiz/steps/VodQASteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/VodQASteps.java
@@ -10,10 +10,11 @@ import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class VodQASteps {
-    private static final Logger LOGGER = Logger.getLogger(VodQASteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(VodQASteps.class.getName());
     private final TestExecutionContext context;
 
     public VodQASteps() {

--- a/src/test/java/com/znsio/teswiz/steps/WeatherAPISteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/WeatherAPISteps.java
@@ -7,11 +7,12 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import kong.unirest.json.JSONObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class WeatherAPISteps {
     private JSONObject jsonObject;
-    private static final Logger LOGGER = Logger.getLogger(WeatherAPISteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(WeatherAPISteps.class.getName());
     private final TestExecutionContext context;
     private String latitude;
     private String longitude;

--- a/src/test/java/com/znsio/teswiz/steps/WindowsSteps.java
+++ b/src/test/java/com/znsio/teswiz/steps/WindowsSteps.java
@@ -8,10 +8,11 @@ import com.znsio.teswiz.runner.Drivers;
 import com.znsio.teswiz.entities.SAMPLE_TEST_CONTEXT;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class WindowsSteps {
-    private static final Logger LOGGER = Logger.getLogger(WindowsSteps.class.getName());
+    private static final Logger LOGGER = LogManager.getLogger(WindowsSteps.class.getName());
     private final TestExecutionContext context;
 
     public WindowsSteps() {


### PR DESCRIPTION
Updated references and calls to Log4j 2.x apis, as mentioned in 
https://logging.apache.org/log4j/2.x/manual/migration.html#option-2-convert-your-application-to-the-log4j-2-api-log4j-api